### PR TITLE
Fix registerViewAssets syntax to work with 5.7.5.9

### DIFF
--- a/blocks/vivid_thumb_gallery/controller.php
+++ b/blocks/vivid_thumb_gallery/controller.php
@@ -138,7 +138,7 @@ class Controller extends BlockController
         }
         return $e;
     }
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $uh = Loader::helper('concrete/urls');
         $bObj = $this->getBlockObject();


### PR DESCRIPTION
When I install the package I get the following error:

```
Declaration of Concrete\Package\VividThumbGallery\Block\VividThumbGallery\Controller::registerViewAssets() should be compatible with Concrete\Core\Block\BlockController::registerViewAssets($outputContent = '')
```

It seems to be a matter of fixing the function signature from `registerViewAssets()` to `registerViewAssets($outputContent = '')`.

Probably one of those non-breaking-changes-but-still-breaks-everything edits in the Core...

Hope this helps this nice add-on stay up to date !

Concrete version: 5.7.5.9
Thumb Gallery version: 1.0.3
