### PR TITLE
Fix thumbnails width in form

### DIFF
--- a/blocks/vivid_thumb_gallery/tools/get_thumbs.php
+++ b/blocks/vivid_thumb_gallery/tools/get_thumbs.php
@@ -69,7 +69,7 @@ $allThumbs = thumbSort($allThumbs,'sort',SORT_ASC);
 foreach($allThumbs as $thumb){
     $file = File::getByID($thumb['fID']);
     $html .= "<div class='thumb-item-shell'>";
-    $html .= "<img src='".$file->getRecentVersion()->getThumbnailURL('file_manager_listing')."'>";
+    $html .= "<img src='".$file->getRecentVersion()->getThumbnailURL('file_manager_listing')."' style='width: 100px; max-width: 100%;'>";
     $html .= "<div class='thumb-file-name'>".$file->getFileName()."</div>";
     $html .= "<input type='hidden' name='fID[]' value='".$file->getFileID()."'>";
     $html .= "<input type='hidden' name='sort[]' class='item-sort'>";


### PR DESCRIPTION
This is how I fixed thumbnails width in my installation.

When pictures are thousands of pixels wide they just leave the popup and make it really hard to sort !

Feel free to fix in a more professional manner !

Not sure how it was intended to work... Is a resize operation missing or do you really use the original size in this listing ?

Before:
![thumbnail_before](https://cloud.githubusercontent.com/assets/5264300/18929239/fb859aa8-85c3-11e6-8d5a-58c984ad275a.png)

After:
![thumbnail_after](https://cloud.githubusercontent.com/assets/5264300/18929244/0097705c-85c4-11e6-8c79-622482344a1d.png)
