### PR TITLE
Unused featherlight.css link

### DIFF
--- a/blocks/vivid_thumb_gallery/controller.php
+++ b/blocks/vivid_thumb_gallery/controller.php
@@ -147,7 +147,6 @@ class Controller extends BlockController
             $blockURL = $uh->getBlockTypeAssetsURL($bt);
             $this->requireAsset('javascript', 'jquery');
             if($this->zoomType=="lightbox"){
-                $this->addHeaderItem('<link rel="stylesheet" type="text/css" href="'.$blockURL.'/assets/featherlight.css"/>');
                 $this->addFooterItem('<script type="text/javascript" src="'.$blockURL.'/assets/imagelightbox.min.js"></script>');
             }
             else{


### PR DESCRIPTION
It seems this library is not used (or not anymore ?).

In my installation I removed it to suppress this annoying 404 error.

The addon seems to work fine without this file.

Already reported and self-closed in #1 for a reason I did not understand.
