### PR TITLE
Issue Fix: PHP 7.1.1 Xenial Xerus: Concrete5.8: registerViewAssets() …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/blocks/vivid_thumb_gallery/controller.php
+++ b/blocks/vivid_thumb_gallery/controller.php
@@ -138,7 +138,7 @@ class Controller extends BlockController
         }
         return $e;
     }
-    public function registerViewAssets()
+    public function registerViewAssets($outputContent = '')
     {
         $uh = Loader::helper('concrete/urls');
         $bObj = $this->getBlockObject();


### PR DESCRIPTION
`registerViewAssets($outputContent = "")` fixes a issue with Concrete5.8 PHP 7.1.1

Full ErrorException:
`Declaration of Concrete\Package\VividThumbGallery\Block\VividThumbGallery\Controller::registerViewAssets() should be compatible with Concrete\Core\Block\BlockController::registerViewAssets($outputContent = '')`

The .gitignore can be ignored.